### PR TITLE
Update runway.lua

### DIFF
--- a/mods/Into The Wild/scripts/missions/runway.lua
+++ b/mods/Into The Wild/scripts/missions/runway.lua
@@ -120,12 +120,15 @@ local function IsRunwayClear(p)
 end
 
 local function GetDistanceFromRunway(p1)
+	local pawn = Board:GetPawn(p1)
+	if not pawn then return 100 end
+	
 	local zone = extract_table(Board:GetZone("plane"))
 
 	local dist = INT_MAX
 
 	for _, p2 in ipairs(zone) do
-		local path = Board:GetPath(p1, p2, Pawn:GetPathProf())
+		local path = Board:GetPath(p1, p2, pawn:GetPathProf())
 		local size = path:size()
 
 		if size < dist then


### PR DESCRIPTION
Ran into a crash due to a nil pawn on the planes mission.
2.8.3, 1.2.86, LMods 1.0.2; running just it and tosx modpack.

The capitalized Pawn was crashing the game on the new turn when the planes are supposed to queue a takeoff. This seemed to fix it (works for first and second plane).