### PR TITLE
Update pilot_engi.lua

### DIFF
--- a/mods/FTL Pilots/scripts/pilot_engi.lua
+++ b/mods/FTL Pilots/scripts/pilot_engi.lua
@@ -43,7 +43,7 @@ function lmn_Engi_Repair:RepairTrain(p2)
 	local train = Board:GetPawn(mission.Train)
 	if train then
 		Board:RemovePawn(train)
-		train = PAWN_FACTORY:CreatePawn("Train_Pawn")
+		train = PAWN_FACTORY:CreatePawn(mission.TrainPawn)
 		Board:AddPawn(train, mission.TrainLoc)
 
 		mission.Train = train:GetId()


### PR DESCRIPTION
Allow Engi to repair any train type by pulling the type string from the mission.