### PR TITLE
Update weapon_vortex_generator.lua

### DIFF
--- a/mods/squads/mods/Vaporware/scripts/squad/weapon_vortex_generator.lua
+++ b/mods/squads/mods/Vaporware/scripts/squad/weapon_vortex_generator.lua
@@ -323,7 +323,7 @@ function vw_Vortex_Generator:GetSkillEffect(p1, p2)
 			local pawn = Board:GetPawn(pawnId) 
 			if pawn then 
 				Board:RemovePawn(pawn) 
-			end
+			end 
 		]], globalPawnIndex)
 
 		ret:AddDelay(0.4)


### PR DESCRIPTION
Add space to script, otherwise it fails when targeting an empty tile with 2 adjacent units.
Tested with no other mods enabled (including in your modpack), ItB 1.2.88, Modloader 2.9.3.
Easy to check the crash in test mech scenario just by aiming.